### PR TITLE
add basic CI with GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: Build and Test
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build-and-test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        node: ['22']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests (CI)
+        env:
+          CI: true
+        run: npm run test-ci
+
+      - name: Build web app
+        run: npm run build

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-  "test-ci": "CI=true react-scripts test --watchAll=false --runInBand --passWithNoTests --json --outputFile=jest-results.json",
+  "test-ci": "react-scripts test --watchAll=false --runInBand --passWithNoTests --json --outputFile=jest-results.json",
     "eject": "react-scripts eject",
     "electron": "electron .",
     "electron-debug": "electron --inspect-brk=9229 .",


### PR DESCRIPTION
add a basic CI workflow for tests and building cross-platform.  Note that this project does not have Jest tests yet.