### PR TITLE
enable asar app bundling

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,14 @@
         "to": "icon.ico"
       }
     ],
-    "asar": false,
+    "asar": true,
+    "asarUnpack": [
+      "assets/**",
+      "data/**",
+      "**/*.node",
+      "**/node_modules/**/build/Release/**",
+      "**/node_modules/native-*/**"
+    ],
     "npmRebuild": false,
     "win": {
       "target": [


### PR DESCRIPTION
When running the packaging script, we get warnings about asar being disabled.  This enables asar.

asarUnpack patterns:

- assets/** and data/**: copy-resources.js copies these into build/, and the app reads things like images and JSON from disk.
- **/*.node
- /node_modules//build/Release/**
- /node_modules/native-*/ : Native modules and compiled artifacts

The above patterns are necessary because the app uses IPC to read files via fs (e.g., read-file, load-image, load-from-json), which requires those targets to be outside app.asar. You ship assets (public/assets) and data (public/data) copied into build/. Those must remain unpacked if read with fs rather than via import/URL. Native modules (if present now or later) must be unpacked to load.

How to test this change:

Install an installer from GHA and then inspect output: Ensure dist/... contains app.asar and an unpacked resources folder (e.g., resources/app.asar.unpacked containing assets and data).

Smoke test key paths:

1. Launch the packaged app
2. Load a template and ensure images render (preload/electron-main.load-image uses fs.readFile).
3. Verify settings save/load (save-to-json/load-from-json).
4. Try “Export Data Merge” dialogue.