### PR TITLE
Update older sample maps

### DIFF
--- a/electron-main.js
+++ b/electron-main.js
@@ -4,7 +4,6 @@ const { ipcMain, dialog } = require('electron');
 const fs = require('fs');
 const path = require('path');
 const xml2js = require('xml2js');
-const { copy } = require('fs-extra');
 
 // Settings relating to Settings.xml
 let curProjectFolder = '';


### PR DESCRIPTION
- In dev-mode, if folder was not already present, app hung because return occurred before creating window.
- If first run since a new install, copy updated maps.
- Change destination folder name to "!All Map Samples", to match GPS repository (and to make it easier to find if Pictures folder has much else in in)