### PR TITLE
Add workflow to upload release assets to website

### DIFF
--- a/.github/workflows/upload-to-website.yml
+++ b/.github/workflows/upload-to-website.yml
@@ -14,15 +14,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Install GitHub CLI
-        run: |
-          type -p curl >/dev/null || (sudo apt update && sudo apt install curl -y)
-          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-          sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-          sudo apt update
-          sudo apt install gh -y
-
       - name: Download release asset (.exe)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that automatically uploads release artifacts to a website via SFTP when a new release is published. The workflow downloads the release .exe installer, generates metadata about it, and uploads both files to a remote server.

- Downloads release .exe assets from GitHub releases
- Generates a JSON metadata file containing version, checksum, size, and download URL
- Uploads the installer and metadata to a website via SFTP